### PR TITLE
fix: Do not escape wildcard in objectclass from admin config

### DIFF
--- a/lib/Horde/Ldap/Filter.php
+++ b/lib/Horde/Ldap/Filter.php
@@ -288,11 +288,12 @@ class Horde_Ldap_Filter
             return self::parse($params['filter']);
         }
         if (!is_array($params['objectclass'])) {
-            return self::create('objectclass', 'equals', $params['objectclass']);
+            // Do not escape values from admin configuration (e.g., '*')
+            return self::create('objectclass', 'equals', $params['objectclass'], false);
         }
         $filters = [];
         foreach ($params['objectclass'] as $objectclass) {
-            $filters[] = self::create('objectclass', 'equals', $objectclass);
+            $filters[] = self::create('objectclass', 'equals', $objectclass, false);
         }
         if (count($filters) == 1) {
             return $filters[0];


### PR DESCRIPTION
The default objectclass filter in Horde's LDAP config is ['\*'], but this value was being escaped to '\2A', resulting in invalid filters like (objectclass=\2A) instead of (objectclass=\*). This patch disables escaping for values coming from trusted configuration.

Values from user input are still escaped to prevent LDAP injection.